### PR TITLE
add direct_connect vif support to aws vpc site

### DIFF
--- a/f5xc/site/aws/vpc/main.tf
+++ b/f5xc/site/aws/vpc/main.tf
@@ -1,14 +1,33 @@
 resource "volterra_aws_vpc_site" "site" {
-  name       = var.f5xc_aws_vpc_site_name
-  namespace  = var.f5xc_namespace
-  aws_region = var.f5xc_aws_region
-  tags       = var.custom_tags
-  labels     = var.f5xc_labels
+  name                     = var.f5xc_aws_vpc_site_name
+  namespace                = var.f5xc_namespace
+  aws_region               = var.f5xc_aws_region
+  tags                     = var.custom_tags
+  labels                   = var.f5xc_labels
+  direct_connect_disabled  = var.f5xc_aws_vpc_direct_connect_disabled
 
   aws_cred {
     name      = var.f5xc_aws_cred
     namespace = var.f5xc_namespace
     tenant    = var.f5xc_tenant
+  }
+
+  dynamic "direct_connect_enabled" {
+    for_each = var.f5xc_aws_vpc_direct_connect_disabled == false ? [1] : []
+    content {
+      cloud_aggregated_prefix      = var.f5xc_aws_vpc_cloud_aggregated_prefix
+      dc_connect_aggregated_prefix = var.f5xc_aws_vpc_dc_connect_aggregated_prefix
+      manual_gw                    = var.f5xc_aws_vpc_direct_connect_manual_gw == true && var.f5xc_aws_vpc_direct_connect_hosted_vifs == false && var.f5xc_aws_vpc_direct_connect_standard_vifs == false ? true : null
+      standard_vifs                = var.f5xc_aws_vpc_direct_connect_manual_gw == false && var.f5xc_aws_vpc_direct_connect_hosted_vifs == false && var.f5xc_aws_vpc_direct_connect_standard_vifs == true ? true : null
+      dynamic "hosted_vifs" {
+        for_each = var.f5xc_aws_vpc_direct_connect_manual_gw == false && var.f5xc_aws_vpc_direct_connect_hosted_vifs != "" && var.f5xc_aws_vpc_direct_connect_standard_vifs == false ? [1] : []
+        content {
+          vifs = var.f5xc_aws_vpc_direct_connect_hosted_vifs
+        }
+      }
+      custom_asn = var.f5xc_aws_vpc_direct_connect_custom_asn
+      auto_asn = var.f5xc_aws_vpc_direct_connect_custom_asn == 0 ? true : null
+    }
   }
 
   dynamic "vpc" {

--- a/f5xc/site/aws/vpc/variables.tf
+++ b/f5xc/site/aws/vpc/variables.tf
@@ -228,3 +228,39 @@ variable "custom_tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "f5xc_aws_vpc_direct_connect_disabled" {
+  type    = bool
+  default = true
+}
+
+variable "f5xc_aws_vpc_direct_connect_manual_gw" {
+  type    = bool
+  default = false
+}
+
+variable "f5xc_aws_vpc_direct_connect_hosted_vifs" {
+  type    = list(string)
+  default = []
+}
+
+variable "f5xc_aws_vpc_direct_connect_standard_vifs" {
+  type    = bool
+  default = false
+}
+
+variable "f5xc_aws_vpc_direct_connect_custom_asn" {
+  type    = number
+  default = 0
+}
+
+variable "f5xc_aws_vpc_cloud_aggregated_prefix" {
+  type    = list(string)
+  default = []
+}
+
+variable "f5xc_aws_vpc_dc_connect_aggregated_prefix" {
+  type    = list(string)
+  default = []
+}
+


### PR DESCRIPTION
Successfully created AWS VPC site with direct connect hosted vif using this module:

```
module "site1" {
  source                          = "./modules/f5xc/site/aws/vpc"
  f5xc_api_p12_file               = var.f5xc_api_p12_file
  f5xc_api_url                    = var.f5xc_api_url
  f5xc_namespace                  = "system"
  f5xc_tenant                     = var.f5xc_tenant
  f5xc_aws_region                 = "us-east-1"
  f5xc_aws_cred                   = "mw-aws-personal"
  #f5xc_aws_cred                   = "mw-aws-f5"
  f5xc_aws_vpc_site_name          = format("%s-aws-vif-1", var.project_prefix)
  f5xc_aws_vpc_name_tag           = format("%s-aws-vif-1", var.project_prefix)
  f5xc_aws_vpc_primary_ipv4       = "192.168.168.0/21"
  f5xc_aws_vpc_total_worker_nodes = 0
  f5xc_aws_ce_gw_type             = "multi_nic"
  f5xc_aws_vpc_direct_connect_disabled = false
  f5xc_aws_vpc_direct_connect_hosted_vifs = [ "dxvif-ffhey2s7" ]
  f5xc_aws_vpc_direct_connect_custom_asn = 64555

  f5xc_aws_vpc_az_nodes           = {
    node0 = {
      f5xc_aws_vpc_workload_subnet = "192.168.168.0/26", f5xc_aws_vpc_inside_subnet = "192.168.168.64/26",
      f5xc_aws_vpc_outside_subnet  = "192.168.168.128/26", f5xc_aws_vpc_az_name = "us-east-1a"
    },
    #    node1 = {
    #      f5xc_aws_vpc_workload_subnet = "192.168.169.0/26", f5xc_aws_vpc_inside_subnet = "192.168.169.64/26",
    #  f5xc_aws_vpc_outside_subnet  = "192.168.169.128/26", f5xc_aws_vpc_az_name = "us-east-1a"
    #},
    #node2 = {
    #  f5xc_aws_vpc_workload_subnet = "192.168.170.0/26", f5xc_aws_vpc_inside_subnet = "192.168.170.64/26",
    #  f5xc_aws_vpc_outside_subnet  = "192.168.170.128/26", f5xc_aws_vpc_az_name = "us-east-1a"
    #}
  }     
  f5xc_aws_default_ce_os_version       = true
  f5xc_aws_default_ce_sw_version       = true
  f5xc_aws_vpc_no_worker_nodes         = false
  f5xc_aws_vpc_use_http_https_port     = true
  f5xc_aws_vpc_use_http_https_port_sli = true
  public_ssh_key                       = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQgmCdK9tbjvfnx417pwhyFhphJUEGsn43bFwjkP6pt mwiget@m1.local"
  custom_tags                          = {
    Owner = "m.wiget@f5.com"
  }
}
```

AWS TGW sites will need some minor fixes. This request only covers AWS VPC sites.