### PR TITLE
aws_creds error preventing TGW site creation

### DIFF
--- a/f5xc/site/aws/tgw/main.tf
+++ b/f5xc/site/aws/tgw/main.tf
@@ -150,7 +150,6 @@ resource "volterra_aws_tgw_site" "site" {
     aws_cred {
       name      = var.f5xc_aws_cred
       namespace = var.f5xc_namespace
-      tenant    = var.f5xc_tenant
     }
     instance_type = var.f5xc_aws_tgw_instance_type
 


### PR DESCRIPTION
removing the tenant attribute from the aws_creds block addresses an error preventing the creation of a TGW site.

No testing has been done to determine whether this change causes regression errors.