### PR TITLE
fix: optional network output

### DIFF
--- a/f5xc/ce/gcp/outputs.tf
+++ b/f5xc/ce/gcp/outputs.tf
@@ -3,7 +3,7 @@ output "ce" {
     master-0 = {
       node    = module.node[0].ce["master-0"]
       config  = module.config[0].ce["master-0"]
-      network = module.network[0].ce["master-0"]
+      network = local.create_network ? module.network[0].ce["master-0"] : null
     }
   }
 }


### PR DESCRIPTION
If we have already created the network, using existing subnets, this output will not exist..

```
│ Error: Invalid index
│ 
│   on .terraform/modules/f5_ce/f5xc/ce/gcp/outputs.tf line 6, in output "ce":
│    6:       network = module.network[0].ce["master-0"]
│     ├────────────────
│     │ module.network is empty tuple
│ 
│ The given key does not identify an element in this collection value: the collection has no elements.
```