### PR TITLE
feat: add use_public_ip parameter to disable public IP on instance

### DIFF
--- a/f5xc/ce/gcp/main.tf
+++ b/f5xc/ce/gcp/main.tf
@@ -50,4 +50,5 @@ module "node" {
   f5xc_ce_gateway_type        = var.f5xc_ce_gateway_type
   f5xc_registration_retry     = var.f5xc_registration_retry
   f5xc_registration_wait_time = var.f5xc_registration_wait_time
+  use_public_ip               = var.use_public_ip
 }

--- a/f5xc/ce/gcp/nodes/main.tf
+++ b/f5xc/ce/gcp/nodes/main.tf
@@ -11,14 +11,16 @@ resource "google_compute_instance" "instance" {
 
   network_interface {
     subnetwork = var.slo_subnetwork
-    access_config {}
+    dynamic "access_config" {
+      for_each = var.use_public_ip ? [1] : []
+      content {}
+    }
   }
 
   dynamic "network_interface" {
     for_each = var.f5xc_ce_gateway_type == var.f5xc_ce_gateway_type_ingress_egress ? [1] : []
     content {
       subnetwork = var.sli_subnetwork
-      access_config {}
     }
   }
 

--- a/f5xc/ce/gcp/nodes/outputs.tf
+++ b/f5xc/ce/gcp/nodes/outputs.tf
@@ -7,7 +7,7 @@ output "ce" {
       labels      = google_compute_instance.instance.labels
       sli_ip      = var.f5xc_ce_gateway_type == var.f5xc_ce_gateway_type_ingress_egress ? google_compute_instance.instance.network_interface[1].network_ip : null
       slo_ip      = google_compute_instance.instance.network_interface[0].network_ip
-      public_ip   = google_compute_instance.instance.network_interface[0].access_config[0].nat_ip
+      public_ip   = var.use_public_ip ? google_compute_instance.instance.network_interface[0].access_config[0].nat_ip : ""
       instance_id = google_compute_instance.instance.instance_id
     }
   }

--- a/f5xc/ce/gcp/nodes/variables.tf
+++ b/f5xc/ce/gcp/nodes/variables.tf
@@ -75,3 +75,9 @@ variable "f5xc_ce_gateway_type_ingress_egress" {
 variable "f5xc_ce_gateway_type" {
   type = string
 }
+
+variable "use_public_ip" {
+  type        = bool
+  default     = true
+  description = "Whether to include the access_config{} into the instance, adding a public Internet IP address, otherwise use NAT."
+}

--- a/f5xc/ce/gcp/outputs.tf
+++ b/f5xc/ce/gcp/outputs.tf
@@ -3,7 +3,7 @@ output "ce" {
     master-0 = {
       node    = module.node[0].ce["master-0"]
       config  = module.config[0].ce["master-0"]
-      network = module.network[0].ce["master-0"]
+      network = local.create_network ? module.network[0].ce["master-0"] : null
     }
   }
 }

--- a/f5xc/ce/gcp/variables.tf
+++ b/f5xc/ce/gcp/variables.tf
@@ -123,6 +123,12 @@ variable "f5xc_namespace" {
   type = string
 }
 
+variable "use_public_ip" {
+  type        = bool
+  default     = true
+  description = "Whether to include the access_config{} into the instance, adding a public Internet IP address, otherwise use NAT."
+}
+
 locals {
   cluster_labels = var.f5xc_fleet_label != "" ? { "ves.io/fleet" = var.f5xc_fleet_label } : {}
 }


### PR DESCRIPTION
Some organizations do not allow compute instances to have a public IP address assigned. This paramter will remove the "access_config" section that is assigning the public IP.

Additionally, a public IP address was being assigned to the "SLI" (inside) interface, which seems wrong as best. That was removed comletely.