### PR TITLE
aws tgw tags and direct_connect standard_vifs fix

### DIFF
--- a/f5xc/site/aws/tgw/main.tf
+++ b/f5xc/site/aws/tgw/main.tf
@@ -1,7 +1,7 @@
 resource "volterra_aws_tgw_site" "site" {
-  name                     = var.f5xc_aws_tgw_site_name
+  name                     = var.f5xc_aws_tgw_name
   labels                   = var.f5xc_aws_tgw_labels
-  tags                     = merge({ "Owner" = var.f5xc_aws_tgw_owner }, var.custom_tags)
+  tags                     = var.custom_tags
   namespace                = var.f5xc_namespace
   description              = var.f5xc_aws_tgw_description
   annotations              = var.f5xc_aws_tgw_annotations
@@ -15,13 +15,15 @@ resource "volterra_aws_tgw_site" "site" {
       cloud_aggregated_prefix      = var.f5xc_aws_tgw_cloud_aggregated_prefix
       dc_connect_aggregated_prefix = var.f5xc_aws_tgw_dc_connect_aggregated_prefix
       manual_gw                    = var.f5xc_aws_tgw_direct_connect_manual_gw == true && var.f5xc_aws_tgw_direct_connect_hosted_vifs == false && var.f5xc_aws_tgw_direct_connect_standard_vifs == false ? true : null
-      standard_vifs                = var.f5xc_aws_tgw_direct_connect_manual_gw == false && var.f5xc_aws_tgw_direct_connect_hosted_vifs == false && var.f5xc_aws_tgw_direct_connect_standard_vifs == true ? true : null
+      standard_vifs                = var.f5xc_aws_tgw_direct_connect_standard_vifs
       dynamic "hosted_vifs" {
         for_each = var.f5xc_aws_tgw_direct_connect_manual_gw == false && var.f5xc_aws_tgw_direct_connect_hosted_vifs != "" && var.f5xc_aws_tgw_direct_connect_standard_vifs == false ? [1] : []
         content {
           vifs = var.f5xc_aws_tgw_direct_connect_hosted_vifs
         }
       }
+      custom_asn = var.f5xc_aws_tgw_direct_connect_custom_asn
+      auto_asn   = var.f5xc_aws_tgw_direct_connect_custom_asn == 0 ? true : null
     }
   }
 
@@ -36,7 +38,6 @@ resource "volterra_aws_tgw_site" "site" {
     default_sw_version        = var.f5xc_aws_default_ce_sw_version
     volterra_software_version = local.f5xc_aws_ce_sw_version
   }
-  tags = var.custom_tags
 
   aws_parameters {
     aws_certified_hw = var.f5xc_aws_certified_hw

--- a/f5xc/site/aws/tgw/variables.tf
+++ b/f5xc/site/aws/tgw/variables.tf
@@ -201,6 +201,11 @@ variable "f5xc_aws_tgw_direct_connect_standard_vifs" {
   default = false
 }
 
+variable "f5xc_aws_tgw_direct_connect_custom_asn" {
+  type    = number
+  default = 0
+}
+
 variable "f5xc_aws_tgw_cloud_aggregated_prefix" {
   type    = list(string)
   default = []


### PR DESCRIPTION
Fix custom_tags and direct_connect for standard_vifs and custom asn.
Successfully deployed 3-node aws tgw site with new subnets and direct connect standard vif config:

```
module "tgw1" {
  source                         = "./modules/f5xc/site/aws/tgw"
  f5xc_tenant                    = var.f5xc_tenant
  f5xc_api_url                   = var.f5xc_api_url
  f5xc_aws_cred                  = var.f5xc_aws_cred
  f5xc_namespace                 = var.f5xc_namespace
  f5xc_api_token                 = var.f5xc_api_token
  f5xc_aws_region                = "us-west-2"
  f5xc_aws_tgw_name              = format("%s-tgw1", var.project_prefix)
  f5xc_aws_default_ce_sw_version = true
  f5xc_aws_default_ce_os_version = true
  f5xc_aws_tgw_no_worker_nodes   = true
  f5xc_aws_tgw_primary_ipv4      = "192.168.168.0/21"
  f5xc_aws_tgw_az_nodes          = {
    node0 : {
      f5xc_aws_tgw_workload_subnet = "192.168.168.0/26",
      f5xc_aws_tgw_inside_subnet   = "192.168.168.64/26",
      f5xc_aws_tgw_outside_subnet  = "192.168.168.128/26",
      f5xc_aws_tgw_az_name         = "us-west-2a"
    },
    node1 : {
      f5xc_aws_tgw_workload_subnet = "192.168.169.0/26",
      f5xc_aws_tgw_inside_subnet   = "192.168.169.64/26",
      f5xc_aws_tgw_outside_subnet  = "192.168.169.128/26",
      f5xc_aws_tgw_az_name         = "us-west-2b"
    },
    node2 : {
      f5xc_aws_tgw_workload_subnet = "192.168.170.0/26",
      f5xc_aws_tgw_inside_subnet   = "192.168.170.64/26",
      f5xc_aws_tgw_outside_subnet  = "192.168.170.128/26",
      f5xc_aws_tgw_az_name         = "us-west-2c"
    }
  }
  f5xc_aws_tgw_direct_connect_disabled = false
  f5xc_aws_tgw_direct_connect_standard_vifs = true
  f5xc_aws_tgw_direct_connect_custom_asn = 64555

  ssh_public_key = var.ssh_public_key
  custom_tags    = local.custom_tags
  providers      = {
    aws      = aws.us-west-2
    volterra = volterra.default
  }
}

locals {
  custom_tags = {
    Owner        = var.owner_tag
    f5xc-tenant  = var.f5xc_tenant
    f5xc-feature = "f5xc-uc01"
  }
}
```