### PR TITLE
[discussion] enable labels for tgw site

### DIFF
--- a/f5xc/site/aws/tgw/main.tf
+++ b/f5xc/site/aws/tgw/main.tf
@@ -203,13 +203,13 @@ resource "volterra_aws_tgw_site" "site" {
   }
 }
 
-/*resource "volterra_cloud_site_labels" "labels" {
+resource "volterra_cloud_site_labels" "labels" {
   name             = volterra_aws_tgw_site.site.name
-  site_type        = "aws_vpc_site"
+  site_type        = "aws_tgw_site"
   # need at least one label, otherwise site_type is ignored
-  labels           = merge({ "key" = "value" }, var.custom_tags)
+  labels           = merge({ "key" = "value" }, var.custom_tags, var.f5xc_aws_tgw_labels)
   ignore_on_delete = var.f5xc_cloud_site_labels_ignore_on_delete
-}*/
+}
 
 resource "volterra_tf_params_action" "aws_tgw_action" {
   site_name       = volterra_aws_tgw_site.site.name

--- a/f5xc/site/aws/tgw/main.tf
+++ b/f5xc/site/aws/tgw/main.tf
@@ -207,7 +207,7 @@ resource "volterra_cloud_site_labels" "labels" {
   name             = volterra_aws_tgw_site.site.name
   site_type        = "aws_tgw_site"
   # need at least one label, otherwise site_type is ignored
-  labels           = merge({ "key" = "value" }, var.custom_tags, var.f5xc_aws_tgw_labels)
+  labels           = merge({ "key" = "value" }, var.f5xc_aws_tgw_labels)
   ignore_on_delete = var.f5xc_cloud_site_labels_ignore_on_delete
 }
 


### PR DESCRIPTION
custom labels for tgw site was missing/disabled and I needed to set a label for SMG (site-mesh). While there is var.5xc_aws_tgw_labels, setting it didn't have any effect. 

So I enabled "volterra_cloud_site_labels" and added that variable as well. I could have used custom_tags, but this label really only makes sense for the volterra tgw site object, not for an aws object.

If this is the way forward, then we'll need to do the same change to aws vpc sites. Comments?

```
module "tgw1" {
. . . 
 f5xc_aws_tgw_labels = {
    "site-mesh" = var.project_prefix
  }
...
}
```

```
  # module.tgw1.volterra_cloud_site_labels.labels will be created
  + resource "volterra_cloud_site_labels" "labels" {
      + id               = (known after apply)
      + ignore_on_delete = true
      + labels           = {
          + "key"       = "value"
          + "site-mesh" = "uc01"
        }
      + name             = "uc01-tgw1"
      + site_type        = "aws_tgw_site"
    }
```
