### PR TITLE
Vk8s kubeconfig

### DIFF
--- a/f5xc/api-credential/main.tf
+++ b/f5xc/api-credential/main.tf
@@ -15,6 +15,7 @@ resource "null_resource" "apply_credential" {
       api_url                 = var.f5xc_api_url
       api_token               = local.f5xc_api_token
       virtual_k8s_name        = var.f5xc_virtual_k8s_name
+      virtual_k8s_namespace   = var.f5xc_virtual_k8s_namespace
       api_credential_type     = var.f5xc_api_credential_type
       api_credentials_name    = var.f5xc_api_credentials_name
       api_credential_password = var.f5xc_api_credential_password

--- a/f5xc/api-credential/scripts/create.sh
+++ b/f5xc/api-credential/scripts/create.sh
@@ -10,7 +10,7 @@ python3 -m pip -qqq --exists-action i --no-input --no-color install --progress-b
 
 if [[ $api_credential_type = "KUBE_CONFIG" ]]
 then
-  python3 $MODULES_PATH/scripts/script.py post $api_url $api_token $tenant $api_credentials_name -v $virtual_k8s_name -c $api_credential_type
+  python3 $MODULES_PATH/scripts/script.py post $api_url $api_token $tenant $api_credentials_name -v $virtual_k8s_name -n $virtual_k8s_namespace -c $api_credential_type
 else
   python3 $MODULES_PATH/scripts/script.py post $api_url $api_token $tenant $api_credentials_name -c $api_credential_type -p $api_credential_password
 fi

--- a/f5xc/site/aws/tgw/main.tf
+++ b/f5xc/site/aws/tgw/main.tf
@@ -203,13 +203,13 @@ resource "volterra_aws_tgw_site" "site" {
   }
 }
 
-/*resource "volterra_cloud_site_labels" "labels" {
+resource "volterra_cloud_site_labels" "labels" {
   name             = volterra_aws_tgw_site.site.name
-  site_type        = "aws_vpc_site"
+  site_type        = "aws_tgw_site"
   # need at least one label, otherwise site_type is ignored
-  labels           = merge({ "key" = "value" }, var.custom_tags)
+  labels           = merge({ "key" = "value" }, var.custom_tags, var.f5xc_aws_tgw_labels)
   ignore_on_delete = var.f5xc_cloud_site_labels_ignore_on_delete
-}*/
+}
 
 resource "volterra_tf_params_action" "aws_tgw_action" {
   site_name       = volterra_aws_tgw_site.site.name

--- a/f5xc/site/aws/tgw/main.tf
+++ b/f5xc/site/aws/tgw/main.tf
@@ -207,7 +207,7 @@ resource "volterra_cloud_site_labels" "labels" {
   name             = volterra_aws_tgw_site.site.name
   site_type        = "aws_tgw_site"
   # need at least one label, otherwise site_type is ignored
-  labels           = merge({ "key" = "value" }, var.custom_tags, var.f5xc_aws_tgw_labels)
+  labels           = merge({ "key" = "value" }, var.f5xc_aws_tgw_labels)
   ignore_on_delete = var.f5xc_cloud_site_labels_ignore_on_delete
 }
 

--- a/f5xc/v8ks/main.tf
+++ b/f5xc/v8ks/main.tf
@@ -45,6 +45,7 @@ module "api_credential_kubeconfig" {
   f5xc_api_token            = local.f5xc_api_token
   f5xc_namespace            = var.f5xc_namespace
   f5xc_virtual_k8s_name     = volterra_virtual_k8s.vk8s.name
+  f5xc_virtual_k8s_namespace = volterra_virtual_k8s.vk8s.namespace
   f5xc_api_credential_type  = "KUBE_CONFIG"
   f5xc_api_credentials_name = var.f5xc_k8s_credentials_name
 }


### PR DESCRIPTION
vk8s kubeconfigs must be created with the namespace of the vk8s:

```
module "vk8s_consul" {
  source                    = "./modules/f5xc/v8ks"
  f5xc_tenant               = var.f5xc_tenant
  f5xc_api_url              = var.f5xc_api_url
  f5xc_api_token            = var.f5xc_api_token
  f5xc_vk8s_name            = format("%s-consul", var.project_prefix)
  f5xc_vk8s_namespace       = module.namespace_consul.namespace["name"]
  f5xc_namespace            = module.namespace_consul.namespace["name"]
  f5xc_create_k8s_creds     = true
  f5xc_k8s_credentials_name = format("%s-vk8s-consul-creds", var.project_prefix)
  f5xc_virtual_site_refs    = [module.virtual_site_consul.virtual-site["name"]]
  f5xc_vsite_refs_namespace = "shared"
}
output "kube_config" {
  value     = module.vk8s_consul.vk8s["k8s_conf"]
  sensitive = true
}
```

I got this error when applying:

```
odule.vk8s_consul.module.api_credential_kubeconfig[0].null_resource.apply_credential (local-exec): POST request url: https://volterra-corp.staging.volterra.us/api/web/namespaces/system/api_c
redentials                                                                                                                                                                                     
module.vk8s_consul.module.api_credential_kubeconfig[0].null_resource.apply_credential (local-exec): {                                                                                          
module.vk8s_consul.module.api_credential_kubeconfig[0].null_resource.apply_credential (local-exec):    "expiration_days": "10",                                                                
module.vk8s_consul.module.api_credential_kubeconfig[0].null_resource.apply_credential (local-exec):    "name": "uc01-vk8s-consul-creds",                                                       
module.vk8s_consul.module.api_credential_kubeconfig[0].null_resource.apply_credential (local-exec):    "namespace": "system",
module.vk8s_consul.module.api_credential_kubeconfig[0].null_resource.apply_credential (local-exec):    "spec": {
module.vk8s_consul.module.api_credential_kubeconfig[0].null_resource.apply_credential (local-exec):       "password": "",
module.vk8s_consul.module.api_credential_kubeconfig[0].null_resource.apply_credential (local-exec):       "type": "KUBE_CONFIG",
module.vk8s_consul.module.api_credential_kubeconfig[0].null_resource.apply_credential (local-exec):       "virtual_k8s_name": "uc01-consul",
module.vk8s_consul.module.api_credential_kubeconfig[0].null_resource.apply_credential (local-exec):       "virtual_k8s_namespace": "default"
module.vk8s_consul.module.api_credential_kubeconfig[0].null_resource.apply_credential (local-exec):    }
module.vk8s_consul.module.api_credential_kubeconfig[0].null_resource.apply_credential (local-exec): }
module.vk8s_consul.module.api_credential_kubeconfig[0].null_resource.apply_credential (local-exec): Response Status Code: 500 --> Response Message: {'code': 13, 'details': [{'type_url': 'type       
.googleapis.com/ves.io.stdlib.server.error.Error', 'value': 'Gno vK8s cluster: uc01-consul found under tenant: volterra-corp-swkjijtd<2023-01-30 16:12:01.385091774 +0000 UTC m=+1300680.138963       
711'}], 'message': 'There was a server error in processing request'}
module.vk8s_consul.module.api_credential_kubeconfig[0].null_resource.apply_credential: Creation complete after 6s [id=6881683356150900541]
module.vk8s_consul.module.api_credential_kubeconfig[0].data.local_file.state: Reading...                                                                                                       
╷
│ Error: Read local file data source error
```

The proposed changes adds  f5xc_vk8s_namespace  and removes the hard coded 'default' to create the api-credential and the kubeconfig successfully:

```
$ terraform output kube_config |grep namespace
    server: https://volterra-corp.staging.volterra.us/api/vk8s/namespaces/uc01-consul/uc01-consul
    namespace: uc01-consul
```

My changes are only validated to get my script to pass. Likely I broke something else. Please review and suggest any changes.
