### PR TITLE
add site label support to vnet sites equal to aws sites

### DIFF
--- a/f5xc/site/azure/main.tf
+++ b/f5xc/site/azure/main.tf
@@ -1,5 +1,6 @@
 resource "volterra_azure_vnet_site" "site" {
   name                     = var.f5xc_azure_site_name
+  labels                   = var.f5xc_azure_vnet_labels
   namespace                = var.f5xc_namespace
   default_blocked_services = var.f5xc_azure_default_blocked_services
   machine_type             = var.f5xc_azure_ce_machine_type
@@ -215,7 +216,7 @@ resource "volterra_cloud_site_labels" "labels" {
   name             = volterra_azure_vnet_site.site.name
   site_type        = var.f5xc_azure_site_kind
   # need at least one label, otherwise site_type is ignored
-  labels           = merge({ "key" = "value" }, var.custom_labels)
+  labels           = merge({ "key" = "value" }, var.f5xc_azure_vnet_labels)
   ignore_on_delete = var.f5xc_cloud_site_labels_ignore_on_delete
 }
 

--- a/f5xc/site/azure/variables.tf
+++ b/f5xc/site/azure/variables.tf
@@ -280,3 +280,8 @@ variable "custom_labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "f5xc_azure_vnet_labels" {
+  type    = map(string)
+  default = {}
+}


### PR DESCRIPTION
This patch matches the label support recently added to AWS TGW sites to Azure Vnet sites:

```
module "vnet1" {                      
  source                              = "./modules/f5xc/site/azure"
  f5xc_namespace                      = "system"
. . .
  f5xc_azure_vnet_labels = {
    "site-mesh" = var.project_prefix
  }
. . .
}
```
