### PR TITLE
adding global network support to tgw from vpc site example

### DIFF
--- a/f5xc/site/aws/tgw/main.tf
+++ b/f5xc/site/aws/tgw/main.tf
@@ -27,6 +27,22 @@ resource "volterra_aws_tgw_site" "site" {
     }
   }
 
+  vn_config {
+    dynamic "global_network_list" {
+      for_each = var.f5xc_aws_tgw_global_network_name
+      content {
+        global_network_connections {
+          sli_to_global_dr {
+            global_vn {
+              name = global_network_list.value
+            }
+          }
+        }
+      }
+    }
+    no_global_network = var.f5xc_aws_tgw_no_global_network
+  }
+
   lifecycle {
     ignore_changes = [labels, description]
   }

--- a/f5xc/site/aws/tgw/variables.tf
+++ b/f5xc/site/aws/tgw/variables.tf
@@ -250,3 +250,14 @@ variable "is_sensitive" {
   type    = bool
   default = false
 }
+
+variable "f5xc_aws_tgw_global_network_name" {
+  type    = list(string)
+  default = []
+}
+
+variable "f5xc_aws_tgw_no_global_network" {
+  type    = bool
+  default = true
+}
+


### PR DESCRIPTION
Adding global network support to AWS TGW sites, using code from AWS VPC site.

```
module "tgw" {
  source "./modules/f5xc/site/aws/tgw"
. . .
  f5xc_aws_tgw_no_global_network = false
  f5xc_aws_tgw_global_network_name = [ volterra_virtual_network.gn.name ]
. . .
}
```
