### PR TITLE
always (re-)create kubeconfig and add f5xc_api_credential_expiry_days

### DIFF
--- a/f5xc/api-credential/locals.tf
+++ b/f5xc/api-credential/locals.tf
@@ -5,6 +5,6 @@ locals {
   state_file         = "${path.module}/_out/${var.f5xc_api_credentials_name}/state.json"
   script_file        = abspath("${path.module}/scripts/script.py")
   venv_path          = abspath(path.module)
+  random_id          = uuid()
 }
-
 

--- a/f5xc/api-credential/main.tf
+++ b/f5xc/api-credential/main.tf
@@ -1,9 +1,10 @@
 resource "null_resource" "apply_credential" {
   triggers = {
-    tenant               = var.f5xc_tenant
-    api_url              = var.f5xc_api_url
-    api_token            = local.f5xc_api_token
-    api_credentials_name = var.f5xc_api_credentials_name
+    # tenant               = var.f5xc_tenant
+    # api_url              = var.f5xc_api_url
+    # api_token            = local.f5xc_api_token
+    # api_credentials_name = var.f5xc_api_credentials_name
+    always               = local.random_id
   }
 
   provisioner "local-exec" {
@@ -11,14 +12,15 @@ resource "null_resource" "apply_credential" {
     interpreter = ["/usr/bin/env", "bash", "-c"]
     on_failure  = fail
     environment = {
-      tenant                  = var.f5xc_tenant
-      api_url                 = var.f5xc_api_url
-      api_token               = local.f5xc_api_token
-      virtual_k8s_name        = var.f5xc_virtual_k8s_name
-      virtual_k8s_namespace   = var.f5xc_virtual_k8s_namespace
-      api_credential_type     = var.f5xc_api_credential_type
-      api_credentials_name    = var.f5xc_api_credentials_name
-      api_credential_password = var.f5xc_api_credential_password
+      tenant                      = var.f5xc_tenant
+      api_url                     = var.f5xc_api_url
+      api_token                   = local.f5xc_api_token
+      virtual_k8s_name            = var.f5xc_virtual_k8s_name
+      virtual_k8s_namespace       = var.f5xc_virtual_k8s_namespace
+      api_credential_type         = var.f5xc_api_credential_type
+      api_credentials_name        = var.f5xc_api_credentials_name
+      api_credential_password     = var.f5xc_api_credential_password
+      api_credential_expiry_days  = var.f5xc_api_credential_expiry_days
     }
   }
 

--- a/f5xc/api-credential/scripts/create.sh
+++ b/f5xc/api-credential/scripts/create.sh
@@ -10,7 +10,7 @@ python3 -m pip -qqq --exists-action i --no-input --no-color install --progress-b
 
 if [[ $api_credential_type = "KUBE_CONFIG" ]]
 then
-  python3 $MODULES_PATH/scripts/script.py post $api_url $api_token $tenant $api_credentials_name -v $virtual_k8s_name -n $virtual_k8s_namespace -c $api_credential_type
+  python3 $MODULES_PATH/scripts/script.py post $api_url $api_token $tenant $api_credentials_name -v $virtual_k8s_name -n $virtual_k8s_namespace -c $api_credential_type -e $api_credential_expiry_days
 else
   python3 $MODULES_PATH/scripts/script.py post $api_url $api_token $tenant $api_credentials_name -c $api_credential_type -p $api_credential_password
 fi

--- a/f5xc/api-credential/scripts/script.py
+++ b/f5xc/api-credential/scripts/script.py
@@ -339,6 +339,7 @@ if __name__ == '__main__':
     parser.add_argument("-c", "--ctype", help="F5XC Credential Type", type=str)
     parser.add_argument("-n", "--namespace", help="F5XC Credential Namespace", type=str)
     parser.add_argument("-p", "--certpw", help="F5XC API Certificate Password", type=str)
+    parser.add_argument("-e", "--expiry", help="F5XC API Credential Expiry Days", type=str)
     args = parser.parse_args()
     apic = APICredential(api_url=args.api_url, api_token=args.api_token, tenant=args.tenant, name=args.name)
 
@@ -359,6 +360,7 @@ if __name__ == '__main__':
             raise ValueError(f'"vk8s" must not be None if "ctype" is of type {F5XCApiCredentialTypes.KUBE_CONFIG.name}')
         apic.credential_type = args.ctype
         apic.virtual_k8s_name = args.vk8s if apic.credential_type == F5XCApiCredentialTypes.KUBE_CONFIG.name else ""
+        apic.expiration_days = args.expiry if apic.credential_type == F5XCApiCredentialTypes.KUBE_CONFIG.name else ""
         apic.virtual_k8s_namespace = args.namespace if apic.credential_type == F5XCApiCredentialTypes.KUBE_CONFIG.name else ""
         apic.certificate_password = args.certpw if apic.credential_type == F5XCApiCredentialTypes.API_CERTIFICATE.name else ""
         print(f"Initiate {Action.POST.name} request")

--- a/f5xc/v8ks/main.tf
+++ b/f5xc/v8ks/main.tf
@@ -38,4 +38,5 @@ module "api_credential_kubeconfig" {
   f5xc_virtual_k8s_namespace = volterra_virtual_k8s.vk8s.namespace
   f5xc_api_credential_type   = "KUBE_CONFIG"
   f5xc_api_credentials_name  = var.f5xc_k8s_credentials_name
+  f5xc_api_credential_expiry_days = var.f5xc_api_credential_expiry_days
 }

--- a/f5xc/v8ks/variables.tf
+++ b/f5xc/v8ks/variables.tf
@@ -62,3 +62,8 @@ variable "is_sensitive" {
   default     = false
   description = "Whether to mask sensitive data in output or not"
 }
+
+variable "f5xc_api_credential_expiry_days" {
+  type    = number
+  default = 10
+}


### PR DESCRIPTION
Previously, kubeconfig got created once via terraform apply with an expiration day in 10 days. This patch makes the expiry_days configurable via vk8s module and always re-creates the kubeconfig when re-applied. This allows the kubeconfig to be renewed.

Working example with expiration in 180 days:

```
odule "vk8s_service" {
  source                          = "./modules/f5xc/v8ks"
  f5xc_tenant                     = var.f5xc_tenant
  f5xc_api_url                    = var.f5xc_api_url
  f5xc_api_token                  = var.f5xc_api_token
  f5xc_vk8s_name                  = var.project_prefix
  f5xc_virtual_k8s_namespace      = module.namespace.namespace["name"]
  f5xc_create_k8s_creds           = true
  f5xc_k8s_credentials_name       = format("%s-vk8s-creds", var.project_prefix)
  f5xc_api_credential_expiry_days = 180
  f5xc_virtual_site_refs          = [module.virtual_site_service.virtual-site["name"]]
  f5xc_vsite_refs_namespace       = "shared"
}
```
