### PR TITLE
adding vsphere site support

### DIFF
--- a/f5xc/ce/vsphere/data.tf
+++ b/f5xc/ce/vsphere/data.tf
@@ -1,0 +1,31 @@
+data "vsphere_datacenter" "dc" {
+  name = var.vsphere_datacenter
+}
+
+data "vsphere_compute_cluster" "cluster" {
+  name          = var.vsphere_cluster
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_datastore" "ds" {
+  for_each         = {for k,v in var.nodes: k => v}
+  name          = each.value.datastore
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_host" "host" {
+  for_each         = {for k,v in var.nodes: k => v}
+  name          = each.value.host
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_network" "outside" {
+  name          = var.outside_network
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_network" "inside" {
+  name          = var.inside_network == "" ? var.outside_network : var.inside_network
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+

--- a/f5xc/ce/vsphere/main.tf
+++ b/f5xc/ce/vsphere/main.tf
@@ -1,0 +1,124 @@
+resource "vsphere_virtual_machine" "vm" {
+  for_each         = {for k,v in var.nodes: k => v}
+  name             = format("%s-%s", var.cluster_name, each.value.name)
+  datacenter_id    = data.vsphere_datacenter.dc.id
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.ds[each.key].id
+  host_system_id   = data.vsphere_host.host[each.key].id
+
+  num_cpus = var.cpus
+  memory   = var.memory
+  guest_id = var.guest_type
+
+  network_interface {
+    network_id   = data.vsphere_network.outside.id
+    adapter_type = "vmxnet3"
+  }
+  dynamic "network_interface" {
+    for_each = var.inside_network == "" ? [] : [0]
+    content {
+      network_id   = data.vsphere_network.inside.id
+      adapter_type = "vmxnet3"
+    }
+  }
+
+  disk {
+    label            = "disk0"
+    size             = 40
+    eagerly_scrub    = false
+    thin_provisioned = false
+  }
+
+  ovf_deploy {
+    allow_unverified_ssl_cert = true
+    local_ovf_path            = var.f5xc_ova_image
+
+    disk_provisioning = "thick"
+
+    ovf_network_map = var.inside_network == "" ? { 
+      "OUTSIDE" = data.vsphere_network.outside.id 
+    } : {
+      "OUTSIDE" = data.vsphere_network.outside.id
+      "REGULAR" = data.vsphere_network.inside.id
+    }
+  }
+
+  vapp {
+    properties = {
+      "guestinfo.ves.certifiedhardware"           = var.certifiedhardware,
+      "guestinfo.interface.0.ip.0.address"        = each.value.ipaddress,
+      "guestinfo.interface.0.name"                = "eth0",
+      "guestinfo.interface.0.route.0.destination" = var.publicdefaultroute,
+      "guestinfo.interface.0.dhcp"                = "no",
+      "guestinfo.interface.0.role"                = "public",
+      "guestinfo.interface.0.route.0.gateway"     = var.publicdefaultgateway,
+      "guestinfo.dns.server.0"                    = var.dnsservers["primary"],
+      "guestinfo.dns.server.1"                    = var.dnsservers["secondary"],
+      "guestinfo.ves.regurl"                      = var.f5xc_reg_url,
+      "guestinfo.hostname"                        = each.value.name,
+      "guestinfo.ves.clustername"                 = var.cluster_name,
+      "guestinfo.ves.latitude"                    = var.sitelatitude,
+      "guestinfo.ves.longitude"                   = var.sitelongitude,
+      "guestinfo.ves.adminpassword"               = var.admin_password,
+      "guestinfo.ves.token"                       = volterra_token.token.id
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      annotation,
+      disk[0].io_share_count,
+      disk[1].io_share_count,
+      disk[2].io_share_count,
+      vapp[0].properties,
+    ]
+  }
+}
+
+resource "volterra_token" "token" {
+  name = format("%s-token", var.cluster_name)
+  namespace = "system"
+}
+
+module "site_wait_for_online" {
+  depends_on     = [volterra_registration_approval.ce]
+  source         = "../../status/site"
+  f5xc_namespace = "system"
+  f5xc_api_token = var.f5xc_api_token
+  f5xc_api_url   = var.f5xc_api_url
+  f5xc_site_name = var.cluster_name
+  f5xc_tenant    = var.f5xc_tenant
+}
+
+resource "volterra_registration_approval" "ce" {
+  for_each      = {for k,v in var.nodes: k => v}
+  depends_on    = [vsphere_virtual_machine.vm[0]]
+  cluster_name  = var.cluster_name
+  hostname      = each.value.name
+  cluster_size  = length(var.nodes)
+  retry = 25
+  wait_time = 30
+}
+
+resource "volterra_site_state" "decommission_when_delete" {
+  name       = var.cluster_name
+  when       = "delete"
+  state      = "DECOMMISSIONING"
+  wait_time  = 60
+  retry      = 5
+  depends_on = [volterra_registration_approval.ce]
+}
+
+resource "volterra_modify_site" "site" {
+  namespace               = "system"
+  name                    = var.cluster_name
+  labels                  = var.custom_labels
+  outside_vip             = var.outside_vip
+  vip_vrrp_mode           = var.outside_vip == "" ? "VIP_VRRP_DISABLE" : "VIP_VRRP_ENABLE"
+  site_to_site_tunnel_ip  = var.outside_vip == "" ? split("/",var.nodes[0]["ipaddress"])[0] : var.outside_vip
+  depends_on              = [volterra_registration_approval.ce]
+}
+
+output "vm" {
+  value = vsphere_virtual_machine.vm
+}

--- a/f5xc/ce/vsphere/variables.tf
+++ b/f5xc/ce/vsphere/variables.tf
@@ -1,0 +1,55 @@
+variable "f5xc_tenant" {}
+variable "f5xc_api_url" {}
+variable "f5xc_api_ca_cert" {}
+variable "f5xc_namespace" {}
+variable "f5xc_api_token" {}
+
+variable "vsphere_server" {}
+variable "vsphere_user" {}
+variable "vsphere_password" {}
+variable "vsphere_datacenter" {}
+variable "vsphere_cluster" {}
+
+variable "nodes" {
+  type = list(object({
+    name      = string
+    datastore = string
+    ipaddress = string
+    host      = string
+  }))
+}
+
+variable "outside_network" {}
+variable "inside_network" {
+  type = string
+  default = ""
+}
+variable "publicdefaultgateway" {}
+variable "dnsservers" {}
+variable "cpus" {}
+variable "memory" {}
+variable "f5xc_ova_image" {}
+variable "f5xc_reg_url" {
+  type    = string
+  default = "ves.volterra.io"
+}
+
+variable "certifiedhardware" {}
+variable "publicdefaultroute" {}
+variable "cluster_name" {}
+variable "guest_type" {}
+variable "sitelatitude" {}
+variable "sitelongitude" {}
+variable "custom_labels" {
+  type  = map(string)
+  default = {}
+}
+variable "outside_vip" {
+  type = string
+  default = ""
+}
+variable "admin_password" {
+  type = string
+  default = ""
+  description = "admin shell password, needs at least one uppercase letter"
+}

--- a/f5xc/ce/vsphere/versions.tf
+++ b/f5xc/ce/vsphere/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    vsphere = {
+      source  = "hashicorp/vsphere"
+      version = ">= 2.3.1"
+    }
+    volterra = {
+      source  = "volterraedge/volterra"
+      version = ">= 0.11.18"
+    }
+  }
+}


### PR DESCRIPTION
Initial support for vsphere ce, ingress only and ingress/egress, single and 3-node sites. Example use can be found currently in https://github.com/mwiget/f5xc-vshpere-ce:

- vsphere1 & vsphere2 are 3-node ingress only sites
- vsphere3 is a single node ingress only site
- vsphere4 is a ingress/egree single node site (sli configured via fleet)

I placed this in f5xc/ce/vsphere, as this pretty much builds the sites from scratch using the ova images and is therefore very different from the public cloud sites, which are found under f5xc/site/ 

Custom VIP for site-mesh-group doesn't work currently and is under investigation. 

