### PR TITLE
adding support for aws internet_vip in vpc and tgw sites

### DIFF
--- a/f5xc/site/aws/tgw/main.tf
+++ b/f5xc/site/aws/tgw/main.tf
@@ -58,6 +58,7 @@ resource "volterra_aws_tgw_site" "site" {
   aws_parameters {
     aws_certified_hw = var.f5xc_aws_certified_hw
     aws_region       = var.f5xc_aws_region
+    enable_internet_vip = var.f5xc_aws_tgw_enable_internet_vip
 
     dynamic "az_nodes" {
       for_each = var.f5xc_aws_tgw_id == "" && var.f5xc_aws_tgw_primary_ipv4 != "" ? var.f5xc_aws_tgw_az_nodes : {}

--- a/f5xc/site/aws/tgw/main.tf
+++ b/f5xc/site/aws/tgw/main.tf
@@ -56,9 +56,10 @@ resource "volterra_aws_tgw_site" "site" {
   }
 
   aws_parameters {
-    aws_certified_hw = var.f5xc_aws_certified_hw
-    aws_region       = var.f5xc_aws_region
-    enable_internet_vip = var.f5xc_aws_tgw_enable_internet_vip
+    aws_certified_hw     = var.f5xc_aws_certified_hw
+    aws_region           = var.f5xc_aws_region
+    enable_internet_vip  = var.f5xc_aws_tgw_enable_internet_vip
+    disable_internet_vip = var.f5xc_aws_tgw_enable_internet_vip ? false : true
 
     dynamic "az_nodes" {
       for_each = var.f5xc_aws_tgw_id == "" && var.f5xc_aws_tgw_primary_ipv4 != "" ? var.f5xc_aws_tgw_az_nodes : {}

--- a/f5xc/site/aws/tgw/variables.tf
+++ b/f5xc/site/aws/tgw/variables.tf
@@ -206,6 +206,11 @@ variable "f5xc_aws_tgw_direct_connect_custom_asn" {
   default = 0
 }
 
+variable "f5xc_aws_tgw_enable_internet_vip" {
+  type    = bool
+  default = false
+}
+
 variable "f5xc_aws_tgw_cloud_aggregated_prefix" {
   type    = list(string)
   default = []

--- a/f5xc/site/aws/vpc/main.tf
+++ b/f5xc/site/aws/vpc/main.tf
@@ -6,6 +6,7 @@ resource "volterra_aws_vpc_site" "site" {
   labels                  = var.f5xc_labels
   direct_connect_disabled = var.f5xc_aws_vpc_direct_connect_disabled
   enable_internet_vip     = var.f5xc_aws_vpc_enable_internet_vip
+  disable_internet_vip    = var.f5xc_aws_vpc_enable_internet_vip ? false : true
 
   aws_cred {
     name      = var.f5xc_aws_cred

--- a/f5xc/site/aws/vpc/main.tf
+++ b/f5xc/site/aws/vpc/main.tf
@@ -5,6 +5,7 @@ resource "volterra_aws_vpc_site" "site" {
   tags                    = var.custom_tags
   labels                  = var.f5xc_labels
   direct_connect_disabled = var.f5xc_aws_vpc_direct_connect_disabled
+  enable_internet_vip     = var.f5xc_aws_vpc_enable_internet_vip
 
   aws_cred {
     name      = var.f5xc_aws_cred

--- a/f5xc/site/aws/vpc/variables.tf
+++ b/f5xc/site/aws/vpc/variables.tf
@@ -247,6 +247,11 @@ variable "f5xc_aws_vpc_direct_connect_custom_asn" {
   default = 0
 }
 
+variable "f5xc_aws_vpc_enable_internet_vip" {
+  type    = bool
+  default = false
+}
+
 variable "f5xc_aws_vpc_cloud_aggregated_prefix" {
   type    = list(string)
   default = []


### PR DESCRIPTION
Add support for enable_internet_vip in was vpc and tgw sites, which got added in volterra 0.11.18
