### PR TITLE
add support for aws vpc and tgw site internet_vip (public LB)

### DIFF
--- a/f5xc/site/aws/tgw/main.tf
+++ b/f5xc/site/aws/tgw/main.tf
@@ -56,8 +56,10 @@ resource "volterra_aws_tgw_site" "site" {
   }
 
   aws_parameters {
-    aws_certified_hw = var.f5xc_aws_certified_hw
-    aws_region       = var.f5xc_aws_region
+    aws_certified_hw     = var.f5xc_aws_certified_hw
+    aws_region           = var.f5xc_aws_region
+    enable_internet_vip  = var.f5xc_aws_tgw_enable_internet_vip
+    disable_internet_vip = var.f5xc_aws_tgw_enable_internet_vip ? false : true
 
     dynamic "az_nodes" {
       for_each = var.f5xc_aws_tgw_id == "" && var.f5xc_aws_tgw_primary_ipv4 != "" ? var.f5xc_aws_tgw_az_nodes : {}

--- a/f5xc/site/aws/tgw/variables.tf
+++ b/f5xc/site/aws/tgw/variables.tf
@@ -206,6 +206,11 @@ variable "f5xc_aws_tgw_direct_connect_custom_asn" {
   default = 0
 }
 
+variable "f5xc_aws_tgw_enable_internet_vip" {
+  type    = bool
+  default = false
+}
+
 variable "f5xc_aws_tgw_cloud_aggregated_prefix" {
   type    = list(string)
   default = []

--- a/f5xc/site/aws/vpc/main.tf
+++ b/f5xc/site/aws/vpc/main.tf
@@ -5,6 +5,8 @@ resource "volterra_aws_vpc_site" "site" {
   tags                    = var.custom_tags
   labels                  = var.f5xc_labels
   direct_connect_disabled = var.f5xc_aws_vpc_direct_connect_disabled
+  enable_internet_vip     = var.f5xc_aws_vpc_enable_internet_vip
+  disable_internet_vip    = var.f5xc_aws_vpc_enable_internet_vip ? false : true
 
   aws_cred {
     name      = var.f5xc_aws_cred

--- a/f5xc/site/aws/vpc/variables.tf
+++ b/f5xc/site/aws/vpc/variables.tf
@@ -247,6 +247,11 @@ variable "f5xc_aws_vpc_direct_connect_custom_asn" {
   default = 0
 }
 
+variable "f5xc_aws_vpc_enable_internet_vip" {
+  type    = bool
+  default = false
+}
+
 variable "f5xc_aws_vpc_cloud_aggregated_prefix" {
   type    = list(string)
   default = []


### PR DESCRIPTION
Adding support for aws vpc and tgw site internet_vip, which creates a public LB on SLO for port 80 and 443 that can be used by a HTTP load balancer object.

AWS VPC example

```
module "ce-eu-north-1" {
  source                               = "./modules/f5xc/site/aws/vpc"
  f5xc_aws_region                      = "eu-north-1"
  f5xc_aws_vpc_site_name               = format("%s-ce1", var.project_prefix)
  f5xc_api_token                       = var.f5xc_api_token
  f5xc_api_url                         = var.f5xc_api_url
  f5xc_tenant                          = var.f5xc_tenant
  f5xc_namespace                       = "system"
  f5xc_aws_cred                        = var.f5xc_aws_cred
  f5xc_aws_vpc_owner                   = var.owner_tag
  f5xc_aws_default_ce_sw_version       = true
  f5xc_aws_default_ce_os_version       = true
  f5xc_aws_ce_gw_type                  = "multi_nic"
  f5xc_aws_vpc_no_worker_nodes         = false
  ssh_public_key                       = var.ssh_public_key
  f5xc_aws_vpc_use_http_https_port     = true
  f5xc_aws_vpc_use_http_https_port_sli = true
  f5xc_aws_vpc_primary_ipv4            = "172.16.32.0/24"
  f5xc_aws_vpc_enable_internet_vip     = true

  f5xc_aws_vpc_az_nodes = {
    node0 = {
      f5xc_aws_vpc_workload_subnet = "172.16.32.0/26",
      f5xc_aws_vpc_inside_subnet   = "172.16.32.64/26",
      f5xc_aws_vpc_outside_subnet  = "172.16.32.128/26",
      f5xc_aws_vpc_az_name         = "eu-north-1a"
    }
  }

  f5xc_labels = {
    "site-mesh" = var.project_prefix
  }
  providers = {
    aws = aws.eu-north-1
  }
}
```

AWS TGW site example:

```
module "tgw1" {
  source                         = "./modules/f5xc/site/aws/tgw"
  f5xc_tenant                    = var.f5xc_tenant
  f5xc_api_url                   = var.f5xc_api_url
  f5xc_aws_cred                  = var.f5xc_aws_cred
  f5xc_namespace                 = var.f5xc_namespace
  f5xc_api_token                 = var.f5xc_api_token
  f5xc_aws_region                = "us-west-2"
  f5xc_aws_tgw_name              = format("%s-tgw1", var.project_prefix)
  f5xc_aws_tgw_owner             = var.owner_tag
  f5xc_aws_default_ce_sw_version = true
  f5xc_aws_default_ce_os_version = true
  f5xc_aws_tgw_no_worker_nodes   = true
  f5xc_aws_tgw_primary_ipv4      = "10.100.0.0/24"
  f5xc_aws_tgw_az_nodes          = {
    node0 : {
      f5xc_aws_tgw_workload_subnet = "10.100.0.0/28",
      f5xc_aws_tgw_inside_subnet   = "10.100.0.16/28",
      f5xc_aws_tgw_outside_subnet  = "10.100.0.32/28",
      f5xc_aws_tgw_az_name         = "us-west-2a"
    },
    node1 : {
      f5xc_aws_tgw_workload_subnet = "10.100.0.48/28",
      f5xc_aws_tgw_inside_subnet   = "10.100.0.64/28",
      f5xc_aws_tgw_outside_subnet  = "10.100.0.80/28",
      f5xc_aws_tgw_az_name         = "us-west-2b"
    },
    node2 : {
      f5xc_aws_tgw_workload_subnet = "10.100.0.96/28",
      f5xc_aws_tgw_inside_subnet   = "10.100.0.112/28",
      f5xc_aws_tgw_outside_subnet  = "10.100.0.128/28",
      f5xc_aws_tgw_az_name         = "us-west-2c"
    }
  }
  f5xc_aws_vpc_attachment_ids = [
    module.spoke11.vpc.id,
    module.spoke12.vpc.id
  ]
  f5xc_aws_tgw_direct_connect_disabled = false
  f5xc_aws_tgw_direct_connect_standard_vifs = true
  f5xc_aws_tgw_direct_connect_custom_asn = 64555
  f5xc_aws_tgw_enable_internet_vip = true

  f5xc_aws_tgw_labels = {
    "site-mesh" = var.project_prefix
  }

  ssh_public_key = var.ssh_public_key
  custom_tags    = local.custom_tags
  providers      = {
    aws      = aws.us-west-2
  }
}
```
