### PR TITLE
remove unused object, no longer needed with secure site mesh object

### DIFF
--- a/f5xc/ce/vsphere/main.tf
+++ b/f5xc/ce/vsphere/main.tf
@@ -120,16 +120,6 @@ resource "volterra_site_state" "decommission_when_delete" {
   depends_on = [volterra_registration_approval.ce]
 }
 
-resource "volterra_modify_site" "site" {
-  namespace               = "system"
-  name                    = var.cluster_name
-  labels                  = var.custom_labels
-  outside_vip             = var.outside_vip
-  vip_vrrp_mode           = var.outside_vip == "" ? "VIP_VRRP_DISABLE" : "VIP_VRRP_ENABLE"
-  site_to_site_tunnel_ip  = var.outside_vip == "" ? split("/",var.nodes[0]["ipaddress"])[0] : var.outside_vip
-  depends_on              = [volterra_registration_approval.ce]
-}
-
 output "vm" {
   value = vsphere_virtual_machine.vm
 }

--- a/f5xc/ce/vsphere/variables.tf
+++ b/f5xc/ce/vsphere/variables.tf
@@ -47,14 +47,6 @@ variable "cluster_name" {}
 variable "guest_type" {}
 variable "sitelatitude" {}
 variable "sitelongitude" {}
-variable "custom_labels" {
-  type  = map(string)
-  default = {}
-}
-variable "outside_vip" {
-  type = string
-  default = ""
-}
 variable "admin_password" {
   type = string
   default = ""


### PR DESCRIPTION
In light of the new secure mesh site object, I no longer need the modify site, which was added here for future use. Removing it.