### PR TITLE
add dhcp support for ipaddress

### DIFF
--- a/f5xc/ce/vsphere/main.tf
+++ b/f5xc/ce/vsphere/main.tf
@@ -60,7 +60,7 @@ resource "vsphere_virtual_machine" "vm" {
       "guestinfo.interface.0.ip.0.address"        = each.value.ipaddress,
       "guestinfo.interface.0.name"                = "eth0",
       "guestinfo.interface.0.route.0.destination" = var.publicdefaultroute,
-      "guestinfo.interface.0.dhcp"                = "no",
+      "guestinfo.interface.0.dhcp"                = each.value.ipaddress == "dhcp" ? "yes": "no",
       "guestinfo.interface.0.role"                = "public",
       "guestinfo.interface.0.route.0.gateway"     = var.publicdefaultgateway,
       "guestinfo.dns.server.0"                    = var.dnsservers["primary"],

--- a/f5xc/ce/vsphere/variables.tf
+++ b/f5xc/ce/vsphere/variables.tf
@@ -24,7 +24,14 @@ variable "inside_network" {
   type = string
   default = ""
 }
-variable "publicdefaultgateway" {}
+variable "publicdefaultgateway" {
+  type = string
+  default = ""
+}
+variable "publicdefaultroute" {
+  type = string
+  default = ""
+}
 variable "dnsservers" {}
 variable "cpus" {}
 variable "memory" {}
@@ -42,7 +49,6 @@ variable "f5xc_reg_url" {
 }
 
 variable "certifiedhardware" {}
-variable "publicdefaultroute" {}
 variable "cluster_name" {}
 variable "guest_type" {}
 variable "sitelatitude" {}


### PR DESCRIPTION
Adding support for dhcp for ipaddress on outside_network:

```
module "vsphere1" {
  source                 = "./modules/f5xc/ce/vsphere"
  f5xc_tenant            = var.f5xc_tenant
  f5xc_api_url           = var.f5xc_api_url
  f5xc_namespace         = var.f5xc_namespace
  f5xc_api_token         = var.f5xc_api_token
  f5xc_api_ca_cert       = var.f5xc_api_ca_cert
  f5xc_reg_url           = var.f5xc_reg_url
  #  f5xc_ova_image         = var.f5xc_ova_image
  f5xc_vm_template       = var.f5xc_vm_template
  vsphere_user           = var.vsphere_user
  vsphere_password       = var.vsphere_password
  vsphere_server         = var.vsphere_server
  vsphere_datacenter     = var.vsphere_datacenter
  vsphere_cluster        = var.vsphere_cluster
  admin_password         = var.admin_password
  nodes   = [
    { name = "master-0", host = "10.200.0.100", datastore = "datastore-esxi-1", ipaddress = "dhcp" },
    { name = "master-1", host = "10.200.0.100", datastore = "datastore-esxi-1", ipaddress = "dhcp" },
    { name = "master-2", host = "10.200.0.100", datastore = "datastore-esxi-1", ipaddress = "dhcp" }
  ]
  outside_network        = "VM Network"
  dnsservers             = {
    primary = "8.8.8.8"
    secondary = "8.8.4.4"
  }
  # publicdefaultgateway   = "10.200.0.1"
  # publicdefaultroute     = "0.0.0.0/0"
  guest_type             = "centos64Guest"
  cpus                   = 4
  memory                 = 16384
  certifiedhardware      = "vmware-voltmesh"
  cluster_name           = format("%s-vsphere1", var.project_prefix)
  sitelatitude           = "37"
  sitelongitude          = "-121"
}
```
