### PR TITLE
Sm connection

### DIFF
--- a/f5xc/ce/azure/locals.tf
+++ b/f5xc/ce/azure/locals.tf
@@ -6,6 +6,7 @@ locals {
   f5xc_ip_ranges_asia       = setunion(var.f5xc_ip_ranges_Asia_TCP, var.f5xc_ip_ranges_Asia_UDP)
   f5xc_ip_ranges_all        = setunion(var.f5xc_ip_ranges_Americas_TCP, var.f5xc_ip_ranges_Americas_UDP, var.f5xc_ip_ranges_Europe_TCP, var.f5xc_ip_ranges_Europe_UDP, var.f5xc_ip_ranges_Asia_TCP, var.f5xc_ip_ranges_Asia_UDP)
   f5xc_azure_resource_group = var.f5xc_existing_azure_resource_group != "" ? var.f5xc_existing_azure_resource_group : azurerm_resource_group.rg[0].name
+  f5xc_azure_security_group_rules_slo = length(var.azure_security_group_rules_slo) > 0 && var.f5xc_is_secure_cloud_ce ? concat(var.azure_security_group_rules_slo, local.azure_security_group_rules_slo_secure_ce) : (length(var.azure_security_group_rules_slo) == 0 && var.f5xc_is_secure_cloud_ce == false ? local.azure_security_group_rules_slo_default : [])
   common_tags               = {
     # "kubernetes.io/cluster/${var.f5xc_cluster_name}" = "owned"
     "Owner" = var.owner_tag

--- a/f5xc/ce/azure/network/node/main.tf
+++ b/f5xc/ce/azure/network/node/main.tf
@@ -52,8 +52,7 @@ resource "azurerm_subnet" "sli" {
 
   /*lifecycle {
     ignore_changes = [
-      azurerm_route_table.sli.id
-      # route_table_id
+      route_table_id
     ]
   }*/
 }

--- a/f5xc/site/aws/tgw/main.tf
+++ b/f5xc/site/aws/tgw/main.tf
@@ -40,7 +40,9 @@ resource "volterra_aws_tgw_site" "site" {
         }
       }
     }
-    no_global_network = var.f5xc_aws_tgw_no_global_network
+    no_global_network       = var.f5xc_aws_tgw_no_global_network
+    sm_connection_public_ip = var.f5xc_aws_tgw_sm_connection_public_ip
+    sm_connection_pvt_ip    = var.f5xc_aws_tgw_sm_connection_public_ip ? false : true
   }
 
   lifecycle {

--- a/f5xc/site/aws/tgw/variables.tf
+++ b/f5xc/site/aws/tgw/variables.tf
@@ -266,3 +266,8 @@ variable "f5xc_aws_tgw_no_global_network" {
   default = true
 }
 
+variable "f5xc_aws_tgw_sm_connection_public_ip" {
+  type    = bool
+  default = true
+}
+

--- a/f5xc/site/aws/vpc/main.tf
+++ b/f5xc/site/aws/vpc/main.tf
@@ -65,8 +65,8 @@ resource "volterra_aws_vpc_site" "site" {
   dynamic "ingress_gw" {
     for_each = var.f5xc_aws_ce_gw_type == var.f5xc_nic_type_single_nic ? [1] : []
     content {
-      sm_connection_public_ip = var.f5xc_sm_connection_public_ip
-      sm_connection_pvt_ip    = var.f5xc_sm_connection_public_ip ? false : true
+      sm_connection_public_ip = var.f5xc_aws_vpc_sm_connection_public_ip
+      sm_connection_pvt_ip    = var.f5xc_aws_vpc_sm_connection_public_ip ? false : true
       aws_certified_hw = var.f5xc_aws_ce_certified_hw[var.f5xc_aws_ce_gw_type]
       allowed_vip_port {
         use_http_https_port = var.f5xc_aws_vpc_use_http_https_port

--- a/f5xc/site/aws/vpc/main.tf
+++ b/f5xc/site/aws/vpc/main.tf
@@ -65,6 +65,8 @@ resource "volterra_aws_vpc_site" "site" {
   dynamic "ingress_gw" {
     for_each = var.f5xc_aws_ce_gw_type == var.f5xc_nic_type_single_nic ? [1] : []
     content {
+      sm_connection_public_ip = var.f5xc_sm_connection_public_ip
+      sm_connection_pvt_ip    = var.f5xc_sm_connection_public_ip ? false : true
       aws_certified_hw = var.f5xc_aws_ce_certified_hw[var.f5xc_aws_ce_gw_type]
       allowed_vip_port {
         use_http_https_port = var.f5xc_aws_vpc_use_http_https_port
@@ -99,7 +101,7 @@ resource "volterra_aws_vpc_site" "site" {
     for_each = var.f5xc_aws_ce_gw_type == var.f5xc_nic_type_multi_nic ? [1] : []
     content {
       sm_connection_public_ip = var.f5xc_sm_connection_public_ip
-      sm_connection_pvt_ip    = var.f5xc_sm_connection_pvt_ip
+      sm_connection_pvt_ip    = var.f5xc_sm_connection_public_ip ? false : true
       aws_certified_hw        = var.f5xc_aws_ce_certified_hw[var.f5xc_aws_ce_gw_type]
       allowed_vip_port {
         use_http_https_port = var.f5xc_aws_vpc_use_http_https_port

--- a/f5xc/site/aws/vpc/variables.tf
+++ b/f5xc/site/aws/vpc/variables.tf
@@ -105,11 +105,6 @@ variable "f5xc_sm_connection_public_ip" {
   default = true
 }
 
-variable "f5xc_sm_connection_pvt_ip" {
-  type    = bool
-  default = false
-}
-
 /*variable "f5xc_aws_vpc_no_outside_static_routes" {
   type    = bool
   default = true

--- a/f5xc/site/aws/vpc/variables.tf
+++ b/f5xc/site/aws/vpc/variables.tf
@@ -100,7 +100,7 @@ variable "f5xc_aws_vpc_no_global_network" {
   default = true
 }
 
-variable "f5xc_sm_connection_public_ip" {
+variable "f5xc_aws_vpc_sm_connection_public_ip" {
   type    = bool
   default = true
 }


### PR DESCRIPTION
default remains sm_connection_public_ip set to true
when set to false, it will set

```
sm_connection_pvt_ip = true
sm_connection_public_ip = false
```

to enable sm_connection_pvt_ip and disable sm_connection_public_ip use:

aws tgw:
```
f5xc_aws_tgw_sm_connection_public_ip = false  
```

aws vpc:
```
f5xc_aws_vpc_sm_connection_public_ip = false
```

I tested this with TGW sites, but haven't tested the change yet with VPC sites. Maybe the CICD could catch potential errors, hence I'm asking to merge with the upcoming 0.11.21 branch.
