### PR TITLE
ignore label changes for gcp sites

### DIFF
--- a/f5xc/site/gcp/main.tf
+++ b/f5xc/site/gcp/main.tf
@@ -191,6 +191,9 @@ resource "volterra_gcp_vpc_site" "site" {
     }
   }
   ssh_key = var.ssh_public_key
+  lifecycle {
+    ignore_changes = [labels]
+  }
 }
 
 resource "volterra_cloud_site_labels" "labels" {


### PR DESCRIPTION
Allows re-apply. Same code as in  aws and azure site module.