### PR TITLE
only numeric value allowed on OS/X

### DIFF
--- a/f5xc/site/virtual/main.tf
+++ b/f5xc/site/virtual/main.tf
@@ -11,6 +11,6 @@ resource "volterra_virtual_site" "virtual_site" {
 
   // This is needed so that there is some time to sync namespace between eywa and akar
   provisioner "local-exec" {
-    command = "sleep 20s"
+    command = "sleep 20"
   }
 }


### PR DESCRIPTION
`sleep` on OS/X only takes numeric values in seconds, not string. The proposed version works on Linux and OS/X

```
$ sleep 20s
usage: sleep seconds
```

